### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To install the plugin, you'll need to add it to your Backstage app's dependencie
 
 **Yarn**
 ```shell
-yarn add --cwd packages/app backstage-plugin-xkcd
+yarn --cwd packages/app add backstage-plugin-xkcd
 ```
 
 ## Integration


### PR DESCRIPTION
Fix yarn add package command to prevent error:
Usage Error: The --cwd option is ambiguous when used anywhere else than the very first parameter provided in the command line, before even the command path